### PR TITLE
Option for using ed25519 ssh keys

### DIFF
--- a/bb.py
+++ b/bb.py
@@ -1320,6 +1320,16 @@ def parse_arguments():
         action="store_true",
     )
 
+    parent_parser.add_argument(
+        "--keytype",
+        "-k",
+        help="Kind of public/private key to use or generate",
+        dest="keytype",
+        action="store",
+        choices=['rsa','ed25519'],
+        default="rsa"
+    )
+
     # Create principal parser
     description = "Butterfly Backup"
     parser_object = argparse.ArgumentParser(
@@ -1348,16 +1358,6 @@ def parse_arguments():
         "config", help="Configuration options", parents=[parent_parser]
     )
     group_config = config.add_argument_group(title="Init configuration")
-
-    config.add_argument(
-        "--keytype",
-        "-k",
-        help="Kind of public/private key to use or generate",
-        dest="keytype",
-        action="store",
-        choices=['rsa','ed25519'],
-        default="rsa"
-    )
 
     group_config_mutually = group_config.add_mutually_exclusive_group()
     group_config_mutually.add_argument(

--- a/bb.py
+++ b/bb.py
@@ -1928,7 +1928,7 @@ def main():
             parser.print_usage()
             exit(1)
         for hostname in hostnames:
-            if not utility.check_ssh(hostname, args.user, port):
+            if not utility.check_ssh(hostname, args.user, args.keytype, port):
                 utility.error(
                     "SSH connection failed on {1}:{0}".format(port, hostname),
                     nocolor=args.color,
@@ -2098,7 +2098,7 @@ def main():
                 )
                 exit(1)
         # Test connection
-        if not utility.check_ssh(rhost, args.user, port):
+        if not utility.check_ssh(rhost, args.user, args.keytype, port):
             utility.error(
                 "SSH connection failed on {1}:{0}".format(port, rhost),
                 nocolor=args.color,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -126,6 +126,7 @@ Butterfly Backup has, in its core, six main operations:
       --no-color, -w        Remove color into terminal
       --explain-error, -x   Print python traceback
       --version, -V         Print version
+      --keytype, -k         Kind of private/public key to use (rsa or ed25519)
 
    action:
       Valid action
@@ -184,7 +185,6 @@ Let's see how to go about looking at the help:
       --force, -O           Force an action without prompt
       --no-color, -w        Remove color into terminal
       --explain-error, -x   Print python traceback
-      --keytype, -k         Kind of private/public key to use (rsa or ed25519)
 
    Init configuration:
       --new, -n             Generate new configuration

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -184,6 +184,7 @@ Let's see how to go about looking at the help:
       --force, -O           Force an action without prompt
       --no-color, -w        Remove color into terminal
       --explain-error, -x   Print python traceback
+      --keytype, -k         Kind of private/public key to use (rsa or ed25519)
 
    Init configuration:
       --new, -n             Generate new configuration

--- a/utility.py
+++ b/utility.py
@@ -349,7 +349,7 @@ def check_tool(name):
     return which(name) is not None
 
 
-def check_ssh(ip, user, port=22):
+def check_ssh(ip, user, keytype, port=22):
     """
     Test ssh connection
     :param ip: ip address or hostname of machine
@@ -360,13 +360,13 @@ def check_ssh(ip, user, port=22):
         return True
     home = os.path.expanduser("~")
     ssh_folder = os.path.join(home, ".ssh")
-    key_filename = os.path.join(ssh_folder, "id_rsa")
-    key_rsa = {"key_filename": key_filename} if os.path.exists(key_filename) else None
+    key_filename = os.path.join(ssh_folder, "id_{0}".format(keytype))
+    key = {"key_filename": key_filename} if os.path.exists(key_filename) else None
     conn = Connection(
         ip,
         port=port,
         user=user,
-        connect_kwargs=key_rsa,
+        connect_kwargs=key,
     )
     try:
         conn.open()


### PR DESCRIPTION
# Option for using ed25519 ssh keys

## List of changes

- ✅ Add parameter `--keytype` to specify either `rsa` or `ed25519` algorithm for public/private key usage and generation.
- ✅ No longer set the passphrase of generated keys to literally 2 times double quotes, but actually use an empty string
- ✅ Update docs to mention the new `--keytype` parameter

### Description of the proposed features

By default, the rsa algorithm is used to generate public/private keys. When deploying public keys to hosts, the default rsa keys will be used. This reflects the behaviour of ButterflyBackup as it was.
With this pull request it is now possible to use the parameter `--keytype ed25519` to not generate a rsa key pair, but an ed25519 key pair. This parameter is valid for all `config` actions.

Also the passphrase is now set to empty when generating a new public/private key.